### PR TITLE
Fixes wasm_log typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ wasm-log = "0.3"
 
 Initialize `wasm-log` when your app start:
 ```rust
-wasm-log::init(wasm-log::Config::default());
+wasm-log::init(wasm_log::Config::default());
 
 // Logging
 log::info!("Some info");
@@ -28,7 +28,7 @@ log::error!("Error message");
 
 You can provide a path prefix:
 ```rust
-wasm-log::init(wasm-log::Config::default().module_prefix("some::module"));
+wasm_log::init(wasm_log::Config::default().module_prefix("some::module"));
 ```
 
 then, `wasm-log` only logs message from `some::module`

--- a/examples/log/src/lib.rs
+++ b/examples/log/src/lib.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]
 pub fn main() -> Result<(), JsValue> {
-    wasm_log::init(wasm - log::Config::default());
+    wasm_log::init(wasm_log::Config::default());
     // Use `web_sys`'s global `window` function to get a handle on the global
     // window object.
     let window = web_sys::window().expect("no global `window` exists");


### PR DESCRIPTION
The README and example both have incorrect wasm_log references.

Otherwise works perfectly, thanks so much for forking and maintaining! :ok_hand: 